### PR TITLE
Add tests for options and popup scripts

### DIFF
--- a/__tests__/options.test.js
+++ b/__tests__/options.test.js
@@ -1,0 +1,83 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
+
+describe('options page', () => {
+  let dom;
+  let loadWebhooks;
+  let saveWebhooks;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <form id="add-webhook-form">
+        <input id="webhook-label" />
+        <input id="webhook-url" />
+        <select id="webhook-method"></select>
+        <input id="webhook-identifier" />
+        <div id="headers-list"></div>
+        <input id="header-key" />
+        <input id="header-value" />
+        <button type="button" id="add-header-btn"></button>
+        <button type="button" id="cancel-edit-btn" class="hidden"></button>
+        <button type="submit"></button>
+      </form>
+      <ul id="webhook-list"></ul>
+      <p id="no-webhooks-message" class="hidden"></p>
+    </body></html>`);
+    global.document = dom.window.document;
+    // Prevent auto-fired DOMContentLoaded handlers from executing
+    dom.window.document.addEventListener = jest.fn();
+    global.window = dom.window;
+    global.Node = dom.window.Node;
+    global.replaceI18nPlaceholders = jest.fn();
+    global.browser = {
+      storage: {
+        sync: {
+          get: jest.fn(),
+          set: jest.fn(),
+        },
+      },
+      i18n: {
+        getMessage: jest.fn().mockImplementation((key) => key),
+      },
+    };
+    ({ loadWebhooks, saveWebhooks } = require('../options/options.js'));
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    dom.window.close();
+    delete global.document;
+    delete global.window;
+    delete global.Node;
+    delete global.browser;
+    delete global.replaceI18nPlaceholders;
+  });
+
+  test('shows message when no webhooks are stored', async () => {
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: [] });
+    await loadWebhooks();
+    const msg = document.getElementById('no-webhooks-message');
+    expect(msg.classList.contains('hidden')).toBe(false);
+    expect(msg.textContent).toBe('optionsNoWebhooksMessage');
+  });
+
+  test('renders list items when webhooks exist', async () => {
+    const hooks = [{ id: '1', label: 'Test', url: 'http://example.com' }];
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+    await loadWebhooks();
+    const items = document.querySelectorAll('#webhook-list li');
+    expect(items.length).toBe(1);
+    const item = items[0];
+    expect(item.dataset.id).toBe('1');
+    expect(item.querySelector('.label').textContent).toBe('Test');
+    expect(item.querySelector('.url').textContent).toBe('http://example.com');
+  });
+
+  test('saveWebhooks writes to storage', async () => {
+    const hooks = [{ id: 'a' }];
+    await saveWebhooks(hooks);
+    expect(global.browser.storage.sync.set).toHaveBeenCalledWith({ webhooks: hooks });
+  });
+});

--- a/__tests__/popup.test.js
+++ b/__tests__/popup.test.js
@@ -1,0 +1,69 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
+
+describe('popup script', () => {
+  let dom;
+  let fetchMock;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <div id="buttons-container"></div>
+      <div id="status-message"></div>
+      <a id="open-options"></a>
+    </body></html>`, { url: 'https://example.com' });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.Node = dom.window.Node;
+    global.replaceI18nPlaceholders = jest.fn();
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+    global.browser = {
+      storage: { sync: { get: jest.fn() } },
+      i18n: { getMessage: jest.fn((key) => key) },
+      tabs: { query: jest.fn() },
+      runtime: {
+        openOptionsPage: jest.fn(),
+        getBrowserInfo: jest.fn().mockResolvedValue({}),
+        getPlatformInfo: jest.fn().mockResolvedValue({}),
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    dom.window.close();
+    delete global.document;
+    delete global.window;
+    delete global.Node;
+    delete global.fetch;
+    delete global.browser;
+    delete global.replaceI18nPlaceholders;
+  });
+
+  test('shows message when no webhooks configured', async () => {
+    browser.storage.sync.get.mockResolvedValue({ webhooks: [] });
+    require('../popup/popup.js');
+    document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    await new Promise(setImmediate);
+    const msg = document.querySelector('.no-hooks-msg');
+    expect(msg).not.toBeNull();
+    expect(msg.textContent).toBe('popupNoWebhooksConfigured');
+  });
+
+  test('clicking webhook button triggers fetch', async () => {
+    const hook = { id: '1', label: 'Send', url: 'https://hook.test' };
+    browser.storage.sync.get.mockResolvedValue({ webhooks: [hook] });
+    browser.tabs.query.mockResolvedValue([{ title: 't', url: 'https://example.com', id: 1, windowId: 1, index: 0, pinned: false, audible: false, mutedInfo: null, incognito: false, status: 'complete' }]);
+    require('../popup/popup.js');
+    document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    await new Promise(setImmediate);
+    const btn = document.querySelector('button.webhook-btn');
+    expect(btn).not.toBeNull();
+    btn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+    await new Promise(setImmediate);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][0]).toBe('https://hook.test');
+  });
+});

--- a/options/options.js
+++ b/options/options.js
@@ -228,3 +228,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // Load webhooks
   loadWebhooks();
 });
+
+// Export functions for testing in Node environment
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { loadWebhooks, saveWebhooks, renderHeaders };
+}

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -148,3 +148,8 @@ document.getElementById("open-options").addEventListener("click", (e) => {
   e.preventDefault();
   browser.runtime.openOptionsPage();
 });
+
+// Export for testing in Node environment
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {};
+}


### PR DESCRIPTION
## Summary
- add Jest tests for options and popup logic
- expose functions from options and popup scripts for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687013e1b5ac832f9cca88f1679aaaea